### PR TITLE
Fix Create Homework Assignment project task

### DIFF
--- a/roles/config-tower/tasks/post-config-tower.yml
+++ b/roles/config-tower/tasks/post-config-tower.yml
@@ -1,5 +1,10 @@
 - name: Create Homework Assignment project
-
+  tower_project:
+    name: "{{ proj_name }}"
+    organization: "{{ org_name }}"
+    scm_type: "{{ scm_type }}"
+    scm_url: "{{ scm_url }}"
+    scm_branch: "{{ scm_branch }}"
 
 - name: Machine Credentail to connect to workstation using openstack.pub
   tower_credential:

--- a/roles/config-tower/vars/main.yml
+++ b/roles/config-tower/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 # vars file for roles/config-tower
 org_name: Default 
+scm_type: git
 scm_branch: master 
 scm_url: "{{ github_repo }}"
 proj_name: "00_Homework Assignment"


### PR DESCRIPTION
Add missing configuration in `post-config-tower.yml` for `Create Homework Assignment project` task

